### PR TITLE
Add ability to extend on Recipient Model for CMS Fields

### DIFF
--- a/src/Model/Recipient.php
+++ b/src/Model/Recipient.php
@@ -170,6 +170,8 @@ class Recipient extends DataObject
         $fields->makeFieldReadonly('ValidateHashExpired');
         $fields->makeFieldReadonly('Verified');
 
+        $this->extend("updateRecipientFields", $fields);
+
         return $fields;
     }
 

--- a/src/Model/Recipient.php
+++ b/src/Model/Recipient.php
@@ -158,6 +158,10 @@ class Recipient extends DataObject
 
     public function getCMSFields()
     {
+        $this->beforeUpdateCMSFields(function ($fields) {
+            $fields->makeFieldReadonly('Verified');
+        });
+
         $fields = parent::getCMSFields();
 
         $fields->removeByName('FileTracking');
@@ -168,9 +172,6 @@ class Recipient extends DataObject
         $fields->makeFieldReadonly('ReceivedCount');
         $fields->makeFieldReadonly('ValidateHash');
         $fields->makeFieldReadonly('ValidateHashExpired');
-        $fields->makeFieldReadonly('Verified');
-
-        $this->extend("updateRecipientFields", $fields);
 
         return $fields;
     }


### PR DESCRIPTION
Previous version of this newsletter module out of the box provided ability to edit Verify checkbox on a Recipient. We need to retain this ability by allowing it to be extended.